### PR TITLE
fix of polygon copy behavior

### DIFF
--- a/summerHTMLImageMapCreator.js
+++ b/summerHTMLImageMapCreator.js
@@ -1015,9 +1015,19 @@ var summerHtmlImageMapCreator = (function() {
      * @returns {Area} - a copy of original area
      */
     Area.copy = function(originalArea) {
-        return Area.fromJSON(originalArea.toJSON()).move(10, 10).select();
+        return Area.fromJSON(JSON.parse(JSON.stringify(originalArea.toJSON()))).move(10, 10).select();
     };
 
+    /**
+     * Returns copy of original area, selected, but not moved
+     *
+     * @param originalArea {Area}
+     * @returns {Area} - a copy of original area
+     */
+    Area.plainCopy = function(originalArea) {
+        return Area.fromJSON(JSON.parse(JSON.stringify(originalArea.toJSON()))).select();
+    };
+    
     /* ---------- Constructors for real areas ---------- */
 
     /**

--- a/summerHTMLImageMapCreator.js
+++ b/summerHTMLImageMapCreator.js
@@ -34,6 +34,8 @@ var summerHtmlImageMapCreator = (function() {
          * @returns {Object} - object with recalculated coordinates, e.g. {x: 100, y: 200}
          */ 
         getRightCoords : function(x, y) {
+            app.recalcOffsetValues();
+
             return {
                 x : x - app.getOffset('x'),
                 y : y - app.getOffset('y')


### PR DESCRIPTION
There was a bug, when you create a copy of any polygon and then move them, the original and the clone or vice-versa.
A quick fix would be to stringify and then parse areas as JSON.

p.s. Also, `plainCopy` method was added.